### PR TITLE
Feat/use title

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Documentation and examples are available at [Documentation](https://github.com/r
 - [useFullScreen](https://github.com/react-tool/hooks/tree/main/docs#usefullscreen)
 - [useDragScroll](https://github.com/react-tool/hooks/tree/main/docs#usedragscroll)
 - [useWindowEventListener](https://github.com/react-tool/hooks/tree/main/docs#usewindoweventlistener)
+- [useTitle](https://github.com/react-tool/hooks/tree/main/docs#useTitle)
 
 <br />
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 - [useFullScreen](https://github.com/react-tool/hooks/tree/main/docs#usefullscreen)
 - [useDragScroll](https://github.com/react-tool/hooks/tree/main/docs#usedragscroll)
 - [useWindowEventListener](https://github.com/react-tool/hooks/tree/main/docs#usewindoweventlistener)
+- [useTitle](https://github.com/react-tool/hooks/tree/main/docs#useTitle)
 
 <br />
 
@@ -267,5 +268,29 @@ export default App;
 
 - `event` (keyof WindowEventMap) : The name of the event.
 - `handler` (function) : A function to handle the event.
+
+<br />
+
+## useTitle
+
+### Usage
+
+```jsx
+import React from "react";
+import { useTitle } from "@react-tool/hooks";
+
+function App() {
+  useTitle("Login Page")
+
+  return <p>Login</p>;
+}
+
+export default App;
+
+```
+
+### Parameters
+
+- `title` (string) : The name of the page.
 
 <br />

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { default as useOutsideClick } from "./useOutsideClick";
 export { default as useFullScreen } from "./useFullScreen";
 export { default as useDragScroll } from "./useDragScroll";
 export { default as useWindowEventListener } from "./useWindowEventListener";
+export { default as useTitle } from "./useTitle";

--- a/src/useTitle.ts
+++ b/src/useTitle.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from "react";
 
 export default function useTitle(title: string) {
   const onChangeTitle = useCallback(() => (document.title = title), [title]);
+
   useEffect(() => {
     onChangeTitle();
   }, [onChangeTitle]);

--- a/src/useTitle.ts
+++ b/src/useTitle.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from "react";
+
+export default function useTitle(initialTitle: string) {
+  const [title, setTitle] = useState(initialTitle);
+  const updateTitle = () => {
+    document.title = title;
+  };
+  useEffect(updateTitle, [title]);
+  return setTitle;
+}

--- a/src/useTitle.ts
+++ b/src/useTitle.ts
@@ -1,10 +1,8 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 
-export default function useTitle(initialTitle: string) {
-  const [title, setTitle] = useState(initialTitle);
-  const updateTitle = () => {
-    document.title = title;
-  };
-  useEffect(updateTitle, [title]);
-  return setTitle;
+export default function useTitle(title: string) {
+  const onChangeTitle = useCallback(() => (document.title = title), [title]);
+  useEffect(() => {
+    onChangeTitle();
+  }, [onChangeTitle]);
 }


### PR DESCRIPTION
UseTitle is a function similar to helmet and serves to change the title of a web page.


## useTitle

### Usage

```jsx
import React from "react";
import { useTitle } from "@react-tool/hooks";

function App() {
  useTitle("Login Page")

  return <p>Login</p>;
}

export default App;

```

### Parameters

- `title` (string) : The name of the page.
